### PR TITLE
Time not showing error fixed

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ const secs = document.getElementById('secs');
 
 
 const formatTime = (time) => {
-    return time < 10 ? `0$(time)` : time;
+    return time < 10 ? `0${time}` : time;
  }
 
 const updateCountDown = (deadline) => {


### PR DESCRIPTION
Just added **Curly braces** around the time variable in formatTime function instead of parentheses.